### PR TITLE
Added namespace alias to sms call

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Since uppercase key names hurt my eyes, there's a helper function to make things
 
 ```clojure
 (def my-sms-message
-  (sms "+442033222504" ;; from
+  (twilio/sms "+442033222504" ;; from
        "+447846012894" ;; to
        "OH HAI!"))     ;; message
 


### PR DESCRIPTION
The call to the sms helper function was a little confusing when it didn't have the twilio namespace in the call, especially considering all the other function calls did. Not a huge deal, but this does make the readme more uniform. 